### PR TITLE
Added json type and some extra tweaks

### DIFF
--- a/include/quince/detail/cell.h
+++ b/include/quince/detail/cell.h
@@ -46,6 +46,7 @@ public:
     void set(const timestamp &);
     void set(const time_type &);
     void set(const date_type &);
+    void set(const json_type &);
     void set(const byte_vector &);
 
     template<typename CxxType>
@@ -70,6 +71,7 @@ public:
     void get(timestamp &) const;
     void get(time_type &) const;
     void get(date_type &) const;
+    void get(json_type &) const;
     void get(byte_vector &) const;
 
     column_type type() const;

--- a/include/quince/detail/cell.h
+++ b/include/quince/detail/cell.h
@@ -47,6 +47,7 @@ public:
     void set(const time_type &);
     void set(const date_type &);
     void set(const json_type &);
+    void set(const jsonb_type &);
     void set(const byte_vector &);
 
     template<typename CxxType>
@@ -72,6 +73,7 @@ public:
     void get(time_type &) const;
     void get(date_type &) const;
     void get(json_type &) const;
+    void get(jsonb_type &) const;
     void get(byte_vector &) const;
 
     column_type type() const;

--- a/include/quince/detail/column_type.h
+++ b/include/quince/detail/column_type.h
@@ -15,6 +15,7 @@
 #include <quince/detail/timestamp.h>
 #include <quince/detail/time_type.h>
 #include <quince/detail/date_type.h>
+#include <quince/detail/json_type.h>
 
 
 /*
@@ -39,6 +40,7 @@ enum class column_type {
     timestamp,
     time_type,
     date_type,
+    json_type,
     byte_vector,
     none
 };
@@ -68,6 +70,7 @@ QUINCE_SPECIFY_COLUMN_TYPE(std::string,             column_type::string)
 QUINCE_SPECIFY_COLUMN_TYPE(quince::timestamp,       column_type::timestamp)
 QUINCE_SPECIFY_COLUMN_TYPE(quince::time_type,       column_type::time_type)
 QUINCE_SPECIFY_COLUMN_TYPE(quince::date_type,       column_type::date_type)
+QUINCE_SPECIFY_COLUMN_TYPE(quince::json_type,       column_type::json_type)
 QUINCE_SPECIFY_COLUMN_TYPE(std::vector<uint8_t>,    column_type::byte_vector)
 QUINCE_SPECIFY_COLUMN_TYPE(boost::none_t,           column_type::none)
 

--- a/include/quince/detail/column_type.h
+++ b/include/quince/detail/column_type.h
@@ -16,6 +16,7 @@
 #include <quince/detail/time_type.h>
 #include <quince/detail/date_type.h>
 #include <quince/detail/json_type.h>
+#include <quince/detail/jsonb_type.h>
 
 
 /*
@@ -41,6 +42,7 @@ enum class column_type {
     time_type,
     date_type,
     json_type,
+    jsonb_type,
     byte_vector,
     none
 };
@@ -71,6 +73,7 @@ QUINCE_SPECIFY_COLUMN_TYPE(quince::timestamp,       column_type::timestamp)
 QUINCE_SPECIFY_COLUMN_TYPE(quince::time_type,       column_type::time_type)
 QUINCE_SPECIFY_COLUMN_TYPE(quince::date_type,       column_type::date_type)
 QUINCE_SPECIFY_COLUMN_TYPE(quince::json_type,       column_type::json_type)
+QUINCE_SPECIFY_COLUMN_TYPE(quince::jsonb_type,      column_type::jsonb_type)
 QUINCE_SPECIFY_COLUMN_TYPE(std::vector<uint8_t>,    column_type::byte_vector)
 QUINCE_SPECIFY_COLUMN_TYPE(boost::none_t,           column_type::none)
 

--- a/include/quince/detail/json_type.h
+++ b/include/quince/detail/json_type.h
@@ -1,0 +1,27 @@
+#ifndef QUINCE__mappers__detail__json_type_h
+#define QUINCE__mappers__detail__json_type_h
+
+//          Copyright KAllsop 2020.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../../../LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <string>
+#include <boost/serialization/strong_typedef.hpp>
+
+
+/*
+    Everything in this file is for quince internal use only.
+*/
+
+// Low-level representation of a json type, as used in a cell.
+//
+// It's the same as the DBMS's on-the-wire representation,
+// so any conversions between this and the representation in user code must be made in wrappers.
+//
+
+namespace quince {
+    BOOST_STRONG_TYPEDEF(std::string, json_type)
+}
+
+#endif

--- a/include/quince/detail/jsonb_type.h
+++ b/include/quince/detail/jsonb_type.h
@@ -1,0 +1,27 @@
+#ifndef QUINCE__mappers__detail__jsonb_type_h
+#define QUINCE__mappers__detail__jsonb_type_h
+
+//          Copyright KAllsop 2020.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../../../LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <string>
+#include <boost/serialization/strong_typedef.hpp>
+
+
+/*
+    Everything in this file is for quince internal use only.
+*/
+
+// Low-level representation of a json type, as used in a cell.
+//
+// It's the same as the DBMS's on-the-wire representation,
+// so any conversions between this and the representation in user code must be made in wrappers.
+//
+
+namespace quince {
+    BOOST_STRONG_TYPEDEF(std::string, jsonb_type)
+}
+
+#endif

--- a/include/quince/mappers/detail/exposed_mapper_type.h
+++ b/include/quince/mappers/detail/exposed_mapper_type.h
@@ -53,7 +53,10 @@ class is_polymorphically_mapped : public std::integral_constant<
     ||  std::is_same<T, timestamp>::value
     ||  std::is_same<T, time_type>::value
     ||  std::is_same<T, date_type>::value
+    ||  std::is_same<T, json_type>::value
     ||  std::is_same<T, std::vector<uint8_t>>::value
+    ||  std::is_base_of< std::array<std::byte, sizeof(T)>, T>::value
+    ||  std::is_base_of< std::vector<std::byte>, T>::value
     ||  std::is_same<T, boost::posix_time::ptime>::value
     ||  std::is_same<T, boost::posix_time::time_duration>::value
     ||  std::is_same<T, boost::gregorian::date>::value

--- a/include/quince/mappers/detail/exposed_mapper_type.h
+++ b/include/quince/mappers/detail/exposed_mapper_type.h
@@ -54,6 +54,7 @@ class is_polymorphically_mapped : public std::integral_constant<
     ||  std::is_same<T, time_type>::value
     ||  std::is_same<T, date_type>::value
     ||  std::is_same<T, json_type>::value
+    ||  std::is_same<T, jsonb_type>::value
     ||  std::is_same<T, std::vector<uint8_t>>::value
     ||  std::is_base_of< std::array<std::byte, sizeof(T)>, T>::value
     ||  std::is_base_of< std::vector<std::byte>, T>::value

--- a/include/quince/mappers/detail/exposed_mapper_type.h
+++ b/include/quince/mappers/detail/exposed_mapper_type.h
@@ -47,6 +47,7 @@ template<typename T>
 class is_polymorphically_mapped : public std::integral_constant<
     bool,
         std::is_arithmetic<T>::value
+    ||  std::is_enum<T>::value
     ||  std::is_same<T, serial>::value
     ||  std::is_same<T, std::string>::value
     ||  std::is_same<T, timestamp>::value

--- a/include/quince/table.h
+++ b/include/quince/table.h
@@ -140,6 +140,11 @@ public:
     using general_table<Value>::specify_key_from_ptkm;
 
 
+    template<typename PtrToKeyMember>
+    void specify_serial_key_part (PtrToKeyMember ptkm) {
+        _serial_mapper = &general_table<Value>::get_value_mapper().lookup(ptkm);
+    }
+
     // --- Everything from here to end of class is for quince internal use only. ---
 
     virtual std::unique_ptr<cloneable>
@@ -147,9 +152,20 @@ public:
         return quince::make_unique<table<Value>>(*this);
     }
 
+    const serial_mapper *
+    readback_mapper() const {
+        if (nullptr != _serial_mapper) {
+            return dynamic_cast<const serial_mapper *>(_serial_mapper);
+        }
+        else {
+           return nullptr;
+        }
+    }
+
 private:
     table(const database &, const std::string &, const mapping_customization &&) = delete;
     template<typename Ptkm> table(const database &, const std::string &, Ptkm, const mapping_customization &&) = delete;
+    const abstract_mapper_base *_serial_mapper = nullptr;
 };
 
 

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -50,6 +50,11 @@ void cell::set(const date_type &src) {
     set_string(src);
 }
 
+void cell::set(const json_type &src) {
+    set_type(get_column_type<json_type>());
+    set_string(src);
+}
+
 void cell::set(const byte_vector &src) {
     set_type(get_column_type<byte_vector>());
     _bytes = src;
@@ -73,6 +78,11 @@ void cell::get(time_type &dest) const {
 
 void cell::get(date_type &dest) const {
     check_type<string>();
+    get_string(dest);
+}
+
+void cell::get(json_type &dest) const {
+    check_type<json_type>();
     get_string(dest);
 }
 

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -55,6 +55,11 @@ void cell::set(const json_type &src) {
     set_string(src);
 }
 
+void cell::set(const jsonb_type &src) {
+    set_type(get_column_type<jsonb_type>());
+    set_string(src);
+}
+
 void cell::set(const byte_vector &src) {
     set_type(get_column_type<byte_vector>());
     _bytes = src;
@@ -83,6 +88,11 @@ void cell::get(date_type &dest) const {
 
 void cell::get(json_type &dest) const {
     check_type<json_type>();
+    get_string(dest);
+}
+
+void cell::get(jsonb_type &dest) const {
+    check_type<jsonb_type>();
     get_string(dest);
 }
 


### PR DESCRIPTION
The following things are added here

1. Support for json type
2. Support for composite key with serial on normal quince table. This does not change the insert method atm so the insert does not return the value generated by the serial.
3. Updates to the is_polymorphically_mapped method to enable the creation of moo common type custom mappers which use enum as there default type.